### PR TITLE
VSDEV-1766: Changes after usage with phoenix-rest

### DIFF
--- a/qrest/auth/__init__.py
+++ b/qrest/auth/__init__.py
@@ -151,7 +151,7 @@ class NetRCAuth(RESTAuthentication):
             except AttributeError as e:
                 raise ValueError('could not expand netrc-path. error is "%s"' % str(e))
             nrc = netrc(file=self.netrc_path)
-            host = urlparse(self.rest_client.url).hostname
+            host = urlparse(self.rest_client.config.url).hostname
             try:
                 (netrc_login, _, netrc_password) = nrc.authenticators(host)
             except TypeError:

--- a/qrest/conf.py
+++ b/qrest/conf.py
@@ -160,7 +160,7 @@ class ResourceConfig:
         #  we cannot set default processor above in the parameters as this means all endpoints
         #  share the same processor instance, and they cross-contaminate . By setting this below
         #  we enforce recreation of a new unique Resource instance each time
-        self.processor = processor or JSONResource()
+        self.processor = processor if processor is not None else JSONResource()
         self.validate()
 
     @classmethod

--- a/qrest/resource.py
+++ b/qrest/resource.py
@@ -26,7 +26,7 @@ from .exception import (
     RestResourceHTTPError,
     InvalidResourceError,
 )
-from .response import JSONResponse
+from .response import CSVResponse, JSONResponse
 
 disable_warnings(InsecureRequestWarning)
 
@@ -486,3 +486,13 @@ class JSONResource(Resource):
         """
 
         self.response = JSONResponse(extract_section, create_attribute)
+
+
+class CSVResource(Resource):
+    """ A REST Resource that expects a text/csv return
+
+    """
+
+    def __init__(self):
+        """Set the use of a CSVResponse."""
+        self.response = CSVResponse()

--- a/qrest/response.py
+++ b/qrest/response.py
@@ -56,7 +56,7 @@ class Response(ABC):
         self.raw = response.content
 
         # We also store the headers with lowercase field names so we become
-        # independent of the case of each fiel name. For example, a response
+        # independent of the case of each field name. For example, a response
         # header can have field "Content-Type", but field "content-type" is
         # also allowed.
         self._headers_lowercase = {name.lower(): value for name, value in self.headers.items()}
@@ -93,8 +93,8 @@ class JSONResponse(Response):
         :param extract_section: This indicates which part of the obtained JSON response contains
             the main payload that should be extracted. The tree is provided as a list of items to
             traverse
-        :param create_attribute: The "results_name" which is the property that will be generated to
-            contain the previously obtained subsection of the json tree
+        :param create_attribute: The name of the attribute that will contain the aforementioned
+            payload subsection.
 
         """
 
@@ -128,7 +128,7 @@ class JSONResponse(Response):
                     json = json[element]
                 else:
                     raise RestResourceMissingContentError(f"Element {element} could not be found")
-            setattr(self, self.create_attribute, json)
+        setattr(self, self.create_attribute, json)
         self.data = json
 
 

--- a/test/test_response.py
+++ b/test/test_response.py
@@ -63,6 +63,24 @@ class JSONResponseTests(unittest.TestCase):
         expected_content = single_post
         self.assertEqual(expected_content, response.fetch())
 
+    def test_store_single_post_as_attribute(self):
+        single_post = _POSTS[0]
+        mock_response = self._create_mock_response(single_post)
+
+        response = JSONResponse()(mock_response)
+
+        expected_content = single_post
+        self.assertEqual(expected_content, response.results)
+
+    def test_store_single_post_as_attribute_with_another_name(self):
+        single_post = _POSTS[0]
+        mock_response = self._create_mock_response(single_post)
+
+        response = JSONResponse(create_attribute="single_post")(mock_response)
+
+        expected_content = single_post
+        self.assertEqual(expected_content, response.single_post)
+
     def test_fetch_body_of_single_post(self):
         single_post = _POSTS[0]
         mock_response = self._create_mock_response(single_post)


### PR DESCRIPTION
phoenix-rest is a Python packages that used qrest when it was still called rest_client. While updating phoenix-rest to work with the latest version of qrest, several issues were detected. This pull request fixes these issues.