### PR TITLE
Use new custom processor for new ResourceConfig

### DIFF
--- a/qrest/conf.py
+++ b/qrest/conf.py
@@ -250,10 +250,14 @@ class ResourceConfig:
         self.parameters = parameters or {}
         self.headers = headers
 
-        #  we cannot set default processor above in the parameters as this means all endpoints
-        #  share the same processor instance, and they cross-contaminate . By setting this below
-        #  we enforce recreation of a new unique Resource instance each time
-        self.processor = processor if processor is not None else JSONResource()
+        if processor is not None:
+            if not isinstance(processor, Resource):
+                raise RestClientConfigurationError("processor must be subclass of RestResource")
+        # The processor is None or it's a Resource instance. If it's a Resource
+        # instance and we use that exact instance for all endpoints, the
+        # endpoints "cross-contaminate". To avoid that, we use a new Resource
+        # instance that is a "clone" of the given one.
+        self.processor = processor.clone() if processor is not None else JSONResource()
         self.validate()
 
     @classmethod

--- a/qrest/resource.py
+++ b/qrest/resource.py
@@ -9,7 +9,7 @@ import requests
 import logging
 import jsonschema
 from urllib.parse import quote, urljoin
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Optional
 from _io import BufferedReader
 
@@ -207,6 +207,11 @@ class Resource(ABC):
     cleaned_data = None
 
     response: Response
+
+    @abstractmethod
+    def clone(self):
+        """Return a new instance created with the same parameters as the current one."""
+        ...
 
     # ---------------------------------------------------------------------------------------------
     def configure(self, name: str, server_url: str, config, auth=None, verify_ssl: bool = False):
@@ -597,14 +602,24 @@ class JSONResource(Resource):
             to contain the previously obtained subsection of the json tree
         """
 
+        self.initial_kwargs = {
+            "extract_section": extract_section,
+            "create_attribute": create_attribute,
+        }
         self.response = JSONResponse(extract_section, create_attribute)
+
+    def clone(self):
+        """Return a new instance created with the same parameters as the current one."""
+        return self.__class__(**self.initial_kwargs)
 
 
 class CSVResource(Resource):
-    """ A REST Resource that expects a text/csv return
-
-    """
+    """A REST Resource that expects a text/csv return"""
 
     def __init__(self):
         """Set the use of a CSVResponse."""
         self.response = CSVResponse()
+
+    def clone(self):
+        """Return a new instance created with the same parameters as the current one."""
+        return self.__class__()

--- a/test/test_create_from_module.py
+++ b/test/test_create_from_module.py
@@ -60,6 +60,19 @@ class CreateAPIFromModuleTests(unittest.TestCase):
 
 @ddt.ddt
 class ResourceConfigCreateTests(unittest.TestCase):
+    def test_use_different_processors(self):
+        class MyConfig(ResourceConfig):
+            name = "my_config"
+            path = ["my", "config"]
+            method = "GET"
+
+            processor = JSONResource()
+
+        config = MyConfig.create()
+        another_config = MyConfig.create()
+
+        self.assertNotEqual(config.processor, another_config.processor)
+
     def test_pass_required_attributes(self):
         class MyConfig(ResourceConfig):
             name = "my_config"


### PR DESCRIPTION
Before this commit, if you would create a new ResourceConfig that was specified with a custom processor instance, the new ResourceConfig would use the same processor as an existing one. With the changes in this commit, if you create a new ResourceConfig it always gets a new processor instance.