### PR TITLE
VSDEV-2392: let qrest exception provide error information

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+ignore_errors = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,6 @@
 [mypy]
 ignore_missing_imports = True
 ignore_errors = True
+
+[mypy-qrest.resource]
+ignore_errors = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,8 @@
 ignore_missing_imports = True
 ignore_errors = True
 
+[mypy-qrest.exception]
+ignore_errors = False
+
 [mypy-qrest.resource]
 ignore_errors = False

--- a/qrest/conf.py
+++ b/qrest/conf.py
@@ -43,7 +43,7 @@ class ParameterConfig:
         choices: Optional[list] = None,
         description: Optional[str] = None,
         schema: Optional[Dict[any, any]] = None,
-        example: Optional[any] = None
+        example: Optional[any] = None,
     ):
         """
         Parameter configuration. Details the name and limitations on the REST parameter and how it
@@ -110,7 +110,7 @@ class ParameterConfig:
 
         if self.schema is not None:
             if not isinstance(self.schema, dict):
-                raise RestClientConfigurationError('parameter schema must be dict')
+                raise RestClientConfigurationError("parameter schema must be dict")
             try:
                 #  Select the correct validator for the provided schema
                 schema_validator_cls = jsonschema.validators.validator_for(self.schema)
@@ -343,7 +343,8 @@ class ResourceConfig:
                 if self.parameters[key].call_location in ["body", "file"]:
                     raise RestClientConfigurationError(
                         "{} parameter not allowed in GET request".format(
-                            self.parameters[key].call_location)
+                            self.parameters[key].call_location
+                        )
                     )
 
     # --------------------------------------------------------------------------------------------

--- a/qrest/conf.py
+++ b/qrest/conf.py
@@ -2,7 +2,7 @@
 Contains the configuration classes to create a :class:`qrest.resource.API`.
 """
 from collections import defaultdict
-from typing import Dict, Optional, Type
+from typing import Dict, List, Optional, Type
 
 import logging
 import jsonschema
@@ -222,7 +222,7 @@ class ResourceConfig:
         headers: Optional[dict] = None,
         processor: Optional[Type[Resource]] = None,
         description: Optional[str] = None,
-        path_description: Optional[dict] = None,
+        path_description: Optional[Dict[str, str]] = None,
     ):
         """
         Constructor, stores externally supplied parameters and validate the quality of it
@@ -245,7 +245,9 @@ class ResourceConfig:
         """
         self.path = path
         self.description = description
-        self.path_description = path_description
+        self.path_description: Dict[
+            str, str
+        ] = path_description if path_description is not None else {}
         self.method = method
         self.parameters = parameters or {}
         self.headers = headers
@@ -372,7 +374,7 @@ class ResourceConfig:
 
     # ---------------------------------------------------------------------------------------------
     @property
-    def path_parameters(self) -> list:
+    def path_parameters(self) -> List[str]:
         """Lists the (always required) path parameters for the specified REST API
         resource. This list is obtained by checking the path list (['api',
         'v2', '{para}', 'details']) for items that are within curly brackets

--- a/qrest/exception.py
+++ b/qrest/exception.py
@@ -119,6 +119,11 @@ class RestBadRequestError(RestResponseError):
         super().__init__(response, f"Bad request for resource {response.url}")
 
 
+class RestUnspecificResponseError(RestResponseError):
+    def __init__(self, response: Response):
+        super().__init__(response, f"REST error {response.status_code}: {response.reason}")
+
+
 def raise_on_response_error(response: Response):
     """Raise custom exception for response status (code) 400 and higher.
 
@@ -137,4 +142,4 @@ def raise_on_response_error(response: Response):
     elif response.status_code == 500:
         raise RestInternalServerError(response)
     else:
-        raise Exception("REST error %d: %s" % (response.status_code, response.reason))
+        raise RestUnspecificResponseError(response)

--- a/qrest/exception.py
+++ b/qrest/exception.py
@@ -77,8 +77,16 @@ class RestResourceMissingContentError(RestClientResourceError):
     pass
 
 
+class RestCredentailsError(RestClientResourceError):
+    """ wrapper exception """
+
+    pass
+
+
 class RestResponseError(RestClientResourceError):
     """Exception due to a requests.Response whose status code indicates an error.
+
+    :ivar response: Response object returned by the request
 
     """
 
@@ -89,11 +97,6 @@ class RestResponseError(RestClientResourceError):
         self.response = response
 
 
-class RestResourceNotFoundError(RestResponseError):
-    def __init__(self, response: Response):
-        super().__init__(response, "Object could not be found in database")
-
-
 class RestAccessDeniedError(RestResponseError):
     def __init__(self, response: Response):
         super().__init__(
@@ -101,10 +104,9 @@ class RestAccessDeniedError(RestResponseError):
         )
 
 
-class RestCredentailsError(RestClientResourceError):
-    """ wrapper exception """
-
-    pass
+class RestBadRequestError(RestResponseError):
+    def __init__(self, response: Response):
+        super().__init__(response, f"Bad request for resource {response.url}")
 
 
 class RestInternalServerError(RestResponseError):
@@ -114,9 +116,9 @@ class RestInternalServerError(RestResponseError):
         )
 
 
-class RestBadRequestError(RestResponseError):
+class RestResourceNotFoundError(RestResponseError):
     def __init__(self, response: Response):
-        super().__init__(response, f"Bad request for resource {response.url}")
+        super().__init__(response, "Object could not be found in database")
 
 
 class RestUnspecificResponseError(RestResponseError):

--- a/qrest/exception.py
+++ b/qrest/exception.py
@@ -106,7 +106,7 @@ class RestAccessDeniedError(RestResponseError):
 
 class RestBadRequestError(RestResponseError):
     def __init__(self, response: Response):
-        super().__init__(response, f"Bad request for resource {response.url}")
+        super().__init__(response, f"Bad request for resource {response.url} ({response.reason})")
 
 
 class RestInternalServerError(RestResponseError):
@@ -118,7 +118,7 @@ class RestInternalServerError(RestResponseError):
 
 class RestResourceNotFoundError(RestResponseError):
     def __init__(self, response: Response):
-        super().__init__(response, "Object could not be found in database")
+        super().__init__(response, f"Object could not be found in database ({response.reason})")
 
 
 class RestUnspecificResponseError(RestResponseError):

--- a/qrest/resource.py
+++ b/qrest/resource.py
@@ -27,7 +27,7 @@ from .exception import (
     RestCredentailsError,
     RestResourceHTTPError,
     InvalidResourceError,
-    RestClientValidationError
+    RestClientValidationError,
 )
 from .response import CSVResponse, JSONResponse
 from .auth import AuthConfig
@@ -160,8 +160,10 @@ class API:
         #  name attribute of a body parameter should be set to None. In that case, only
         #  one body parameter is allowed.
         if b_names.count(None) > 0 and len(b_names) > 1:
-            msg = "No additional body parameters allowed if body parameter " \
-                  "has name attribute with value None."
+            msg = (
+                "No additional body parameters allowed if body parameter "
+                "has name attribute with value None."
+            )
             raise RestClientConfigurationError(msg)
 
         processor.configure(
@@ -369,7 +371,7 @@ class Resource(ABC):
                 try:
                     schema_validator_cls(config.schema).validate(instance)
                 except jsonschema.ValidationError:
-                    msg = 'value for {} does not obey schema'.format(parameter)
+                    msg = "value for {} does not obey schema".format(parameter)
                     raise RestClientValidationError(msg)
 
         # ----------------------------------
@@ -399,30 +401,30 @@ class Resource(ABC):
         for parameter in kwargs:
             if parameter not in self.config.parameters:
                 continue
-            if self.config.parameters[parameter].call_location != 'file':
+            if self.config.parameters[parameter].call_location != "file":
                 continue
             val = kwargs[parameter]
             if not isinstance(val, tuple):
                 raise RestClientConfigurationError(
                     "parameter {} should be tuple (filename(str), file(BufferedReader))".format(
-                        parameter)
+                        parameter
                     )
+                )
             if len(val) != 2:
                 raise RestClientConfigurationError(
                     "parameter {} should be tuple (filename(str), file(BufferedReader)) of "
-                    "size 2".format(
-                        parameter)
-                    )
+                    "size 2".format(parameter)
+                )
             if not isinstance(val[0], str):
                 raise RestClientConfigurationError(
-                    "First item of parameter {} (tuple) should be str (filename)".format(
-                        parameter)
-                    )
+                    "First item of parameter {} (tuple) should be str (filename)".format(parameter)
+                )
             if not isinstance(val[1], BufferedReader):
                 raise RestClientConfigurationError(
                     "Second item of parameter {} (tuple) should be BufferedReader (file)".format(
-                        parameter)
+                        parameter
                     )
+                )
 
         # apply defaults for missing optional parameters that do have default values
         defaults = self.config.defaults
@@ -496,7 +498,7 @@ class Resource(ABC):
         return_structure = {
             "request": request_parameters,
             "body": body_parameters,
-            "file": file_parameters
+            "file": file_parameters,
         }
 
         return return_structure
@@ -548,14 +550,14 @@ class Resource(ABC):
                 if len(item[1]) != 2:
                     raise RestClientQueryError(
                         f"extra_file item[1] should have two items: {item[1]}"
-                        )
+                    )
                 if not isinstance(item[1][0], str):
                     raise RestClientQueryError(f"extra_file item[1][0] is not str: {item[1][0]}")
                 if not isinstance(item[1][1], BufferedReader):
                     raise RestClientQueryError(
                         f"extra_file item[1][1] is not BufferedReader: {item[1][1]}"
-                        )
-            query_parameters['file'].extend(extra_file)
+                    )
+            query_parameters["file"].extend(extra_file)
 
         # Do HTTP request to REST API
         logger.debug(" running %s" % self.query_url)

--- a/qrest/resource.py
+++ b/qrest/resource.py
@@ -10,7 +10,7 @@ import logging
 import jsonschema
 from urllib.parse import quote, urljoin
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
 from _io import BufferedReader
 
 from requests.packages.urllib3 import disable_warnings
@@ -18,6 +18,9 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 # ================================================================================================
 # local imports
+if TYPE_CHECKING:
+    # we import ResourceConfig for type checking only to avoid a circular import
+    from .conf import ResourceConfig
 from .module_class_registry import ModuleClassRegistry
 from .response import Response
 from .utils import URLValidator
@@ -200,13 +203,13 @@ class Resource(ABC):
     """
 
     is_configured = False
-    config = None
+    config: Optional["ResourceConfig"] = None
 
     server_url = None
     request_parameters = None
     verify_ssl = False
     auth = None
-    cleaned_data = None
+    cleaned_data: Optional[Dict[str, Any]] = None
 
     response: Response
 
@@ -224,7 +227,14 @@ class Resource(ABC):
         pass
 
     # ---------------------------------------------------------------------------------------------
-    def configure(self, name: str, server_url: str, config, auth=None, verify_ssl: bool = False):
+    def configure(
+        self,
+        name: str,
+        server_url: str,
+        config: "ResourceConfig",
+        auth=None,
+        verify_ssl: bool = False,
+    ):
         """Configure the resource. This is a required procedure to set all parameters.
         Setting these parameters is not possible by using __init__, because
         this class is initialized within the config, to enable setting custom
@@ -277,6 +287,7 @@ class Resource(ABC):
         (value, a list)
 
         """
+        assert self.config is not None
         return self.config.as_dict
 
     # ---------------------------------------------------------------------------------------------
@@ -292,6 +303,7 @@ class Resource(ABC):
         Return string description of the endpoint and the parameters
         :param parameter_name: Optional parameter name to request the help text of
         """
+        assert self.config is not None
         if not parameter_name:
             return self.config.description or "No description given for this endpoint"
         if parameter_name not in self.config.all_parameters:

--- a/qrest/resource.py
+++ b/qrest/resource.py
@@ -28,9 +28,9 @@ from .exception import (
     RestClientQueryError,
     RestClientConfigurationError,
     RestCredentailsError,
-    RestResourceHTTPError,
     InvalidResourceError,
     RestClientValidationError,
+    raise_on_response_error,
 )
 from .response import CSVResponse, JSONResponse
 from .auth import AuthConfig
@@ -586,11 +586,7 @@ class Resource(ABC):
             )
             assert isinstance(response, requests.Response)
 
-            if response.status_code > 399:  # Nicely catch exceptions
-                raise RestResourceHTTPError(response_object=response)
-            # for completeness sake: let requests check for valid output
-            # code should not get here...
-            response.raise_for_status()
+            raise_on_response_error(response)
         except ValueError:
             # Weird response errors: just give back the raw data. This has the risk of dismissing
             # valid errors!

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,9 @@ tomli==2.0.1
 tqdm==4.48.2
 twine==3.2.0
 typed-ast==1.4.1
-typing_extensions==4.1.1
+types-requests==2.27.10
+types-urllib3==1.26.9
+typing-extensions==4.1.1
 urllib3==1.25.9
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ keyring==21.3.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
 more-itertools==8.4.0
+mypy==0.931
+mypy-extensions==0.4.3
 packaging==20.4
 pathspec==0.8.0
 pkginfo==1.5.0.1
@@ -35,6 +37,7 @@ pycparser==2.20
 pyflakes==2.2.0
 Pygments==2.6.1
 pyparsing==2.4.7
+pyrsistent==0.18.1
 pytest==5.4.3
 pytz==2020.1
 readme-renderer==26.0
@@ -55,9 +58,11 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
 toml==0.10.1
+tomli==2.0.1
 tqdm==4.48.2
 twine==3.2.0
 typed-ast==1.4.1
+typing_extensions==4.1.1
 urllib3==1.25.9
 wcwidth==0.2.5
 webencodings==0.5.1

--- a/test/jsonplaceholderconfig.py
+++ b/test/jsonplaceholderconfig.py
@@ -67,21 +67,15 @@ class CreatePostWithSchema(ResourceConfig):
     description = "Create a new post"
 
     schema = {
-                "title": "create post",
-                "description": "a schema to create a post",
-                "type": "object",
-                "properties": {
-                    "user": {
-                        "description": "id of the user",
-                        "type": "string"
-                    },
-                    "body": {
-                        "description": "the body of the post",
-                        "type": "string"
-                    }
-                },
-                "required": ["user", "body"]
-     }
+        "title": "create post",
+        "description": "a schema to create a post",
+        "type": "object",
+        "properties": {
+            "user": {"description": "id of the user", "type": "string"},
+            "body": {"description": "the body of the post", "type": "string"},
+        },
+        "required": ["user", "body"],
+    }
 
     post = BodyParameter(name=None, required=True, schema=schema)
 
@@ -93,4 +87,4 @@ class UploadFile(ResourceConfig):
     method = "POST"
     description = "upload a file"
 
-    file = FileParameter(name='file', required=True, description="The file to be uploaded")
+    file = FileParameter(name="file", required=True, description="The file to be uploaded")

--- a/test/test_configuration.py
+++ b/test/test_configuration.py
@@ -54,10 +54,9 @@ class TestParameters(unittest.TestCase):
 
     def test_good_query_parameters(self):
         parameters = {
-            "para": QueryParameter(name="sort",
-                                   default="some_default",
-                                   description="description",
-                                   example='foobar')
+            "para": QueryParameter(
+                name="sort", default="some_default", description="description", example="foobar"
+            )
         }
         self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
@@ -116,17 +115,13 @@ class TestParameters(unittest.TestCase):
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
     def test_good_example_with_choices(self):
-        parameters = {"para": QueryParameter(name="sort",
-                                             example=3,
-                                             choices=[1, 2, 3])}
+        parameters = {"para": QueryParameter(name="sort", example=3, choices=[1, 2, 3])}
         self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
     def test_bad_example_with_choices(self):
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": QueryParameter(name="sort",
-                                                 example=3,
-                                                 choices=[1, 2, 4])}
+            parameters = {"para": QueryParameter(name="sort", example=3, choices=[1, 2, 4])}
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "example should be one of the choices")
@@ -134,9 +129,9 @@ class TestParameters(unittest.TestCase):
     def test_schema_with_choices(self):
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": QueryParameter(name="sort",
-                                                 schema={'type': 'string'},
-                                                 choices=[1, 2, 4])}
+            parameters = {
+                "para": QueryParameter(name="sort", schema={"type": "string"}, choices=[1, 2, 4])
+            }
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "choices and schema can't be combined")
@@ -166,7 +161,7 @@ class TestParameters(unittest.TestCase):
 
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": FileParameter(name="test", schema={'type': 'string'})}
+            parameters = {"para": FileParameter(name="test", schema={"type": "string"})}
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         msg = "parameter 'schema' should be 'None' for FileParameter"
@@ -181,55 +176,44 @@ class TestParameters(unittest.TestCase):
         self.assertEqual(exc.exception.args[0], msg)
 
     def test_good_schema_parameters(self):
-        parameters = {"para": BodyParameter(name="foo",
-                                            schema={'type': 'boolean'},
-                                            example=True)}
+        parameters = {"para": BodyParameter(name="foo", schema={"type": "boolean"}, example=True)}
 
-        self.UrlApiConfig({"ep": ResourceConfig(path=[""],
-                                                method="POST",
-                                                parameters=parameters)})
+        self.UrlApiConfig({"ep": ResourceConfig(path=[""], method="POST", parameters=parameters)})
 
-        parameters = {"para": QueryParameter(name="foo",
-                                             schema={'type': 'integer'},
-                                             default=4)}
+        parameters = {"para": QueryParameter(name="foo", schema={"type": "integer"}, default=4)}
 
-        self.UrlApiConfig({"ep": ResourceConfig(path=[""],
-                                                method="POST",
-                                                parameters=parameters)})
+        self.UrlApiConfig({"ep": ResourceConfig(path=[""], method="POST", parameters=parameters)})
 
     def test_bad_schema_parameters(self):
 
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": BodyParameter(name="foo",
-                                                schema="bar")}
+            parameters = {"para": BodyParameter(name="foo", schema="bar")}
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "parameter schema must be dict")
 
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": QueryParameter(name="foo",
-                                                 schema={'type': 'ni'},
-                                                 example="bar")}
+            parameters = {"para": QueryParameter(name="foo", schema={"type": "ni"}, example="bar")}
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "provided schema is not a valid schema")
 
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": BodyParameter(name="foo",
-                                                schema={'type': 'boolean'},
-                                                example="bar")}
+            parameters = {
+                "para": BodyParameter(name="foo", schema={"type": "boolean"}, example="bar")
+            }
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "example does not obey schema")
 
         with self.assertRaises(RestClientConfigurationError) as exc:
 
-            parameters = {"para": QueryParameter(name="foo",
-                                                 schema={'type': 'boolean'},
-                                                 default="bar")}
+            parameters = {
+                "para": QueryParameter(name="foo", schema={"type": "boolean"}, default="bar")
+            }
             self.UrlApiConfig(_create_endpoints(parameters=parameters))
 
         self.assertEqual(exc.exception.args[0], "default does not obey schema")

--- a/test/test_create_from_module.py
+++ b/test/test_create_from_module.py
@@ -145,9 +145,11 @@ class ResourceConfigCreateTests(unittest.TestCase):
         with mock.patch.object(MyConfig, "__init__", return_value=None) as init_dunder:
             _ = MyConfig.create()
 
-            expected_parameters = {"title": MyConfig.title,
-                                   "user_id": MyConfig.user_id,
-                                   "file": MyConfig.file}
+            expected_parameters = {
+                "title": MyConfig.title,
+                "user_id": MyConfig.user_id,
+                "file": MyConfig.file,
+            }
 
             _, kwargs = init_dunder.call_args
             self.assertDictEqual({"parameters": expected_parameters}, kwargs)

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -23,6 +23,7 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
             raise_on_response_error(response)
 
         exc = cm.exception
+        self.assertIs(exc.response, response)
         self.assertEqual(
             "Bad request for resource https://jsonplaceholder.typicode.com/posts", str(exc)
         )
@@ -36,6 +37,7 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
             raise_on_response_error(response)
 
         exc = cm.exception
+        self.assertIs(exc.response, response)
         self.assertEqual("Object could not be found in database", str(exc))
 
     @ddt.data(401, 402, 403)
@@ -48,6 +50,7 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
             raise_on_response_error(response)
 
         exc = cm.exception
+        self.assertIs(exc.response, response)
         self.assertEqual(
             f"error {status_code}: "
             "Access is denied to resource https://jsonplaceholder.typicode.com/posts",
@@ -64,6 +67,7 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
             raise_on_response_error(response)
 
         exc = cm.exception
+        self.assertIs(exc.response, response)
         self.assertEqual("error 500: Internal Server error (reason)", str(exc))
 
     def test_raise_on_600(self):

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -8,6 +8,7 @@ from qrest.exception import (
     RestBadRequestError,
     RestInternalServerError,
     RestResourceNotFoundError,
+    RestUnspecificResponseError,
     raise_on_response_error,
 )
 
@@ -76,10 +77,11 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
         response.status_code = 600
         response.reason = "reason"
 
-        with self.assertRaises(Exception) as cm:
+        with self.assertRaises(RestUnspecificResponseError) as cm:
             raise_on_response_error(response)
 
         exc = cm.exception
+        self.assertIs(exc.response, response)
         self.assertEqual("REST error 600: reason", str(exc))
 
     @ddt.data(100, 200, 300, 399)

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -1,0 +1,87 @@
+import unittest
+
+import ddt
+import requests
+
+from qrest.exception import (
+    RestAccessDeniedError,
+    RestBadRequestError,
+    RestInternalServerError,
+    RestResourceNotFoundError,
+    raise_on_response_error,
+)
+
+
+@ddt.ddt
+class RaiseOnResponseErrorTests(unittest.TestCase):
+    def test_raise_on_400(self):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = 400
+
+        with self.assertRaises(RestBadRequestError) as cm:
+            raise_on_response_error(response)
+
+        exc = cm.exception
+        self.assertEqual(
+            "Bad request for resource https://jsonplaceholder.typicode.com/posts", str(exc)
+        )
+
+    def test_raise_on_404(self):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = 404
+
+        with self.assertRaises(RestResourceNotFoundError) as cm:
+            raise_on_response_error(response)
+
+        exc = cm.exception
+        self.assertEqual("Object could not be found in database", str(exc))
+
+    @ddt.data(401, 402, 403)
+    def test_raise_on_40x(self, status_code):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = status_code
+
+        with self.assertRaises(RestAccessDeniedError) as cm:
+            raise_on_response_error(response)
+
+        exc = cm.exception
+        self.assertEqual(
+            f"error {status_code}: "
+            "Access is denied to resource https://jsonplaceholder.typicode.com/posts",
+            str(exc),
+        )
+
+    def test_raise_on_500(self):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = 500
+        response.reason = "reason"
+
+        with self.assertRaises(RestInternalServerError) as cm:
+            raise_on_response_error(response)
+
+        exc = cm.exception
+        self.assertEqual("error 500: Internal Server error (reason)", str(exc))
+
+    def test_raise_on_600(self):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = 600
+        response.reason = "reason"
+
+        with self.assertRaises(Exception) as cm:
+            raise_on_response_error(response)
+
+        exc = cm.exception
+        self.assertEqual("REST error 600: reason", str(exc))
+
+    @ddt.data(100, 200, 300, 399)
+    def test_status_code_below_400_doesnt_raise_an_exception(self, status_code):
+        response = requests.Response()
+        response.url = "https://jsonplaceholder.typicode.com/posts"
+        response.status_code = status_code
+
+        raise_on_response_error(response)

--- a/test/test_exception.py
+++ b/test/test_exception.py
@@ -19,6 +19,7 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
         response = requests.Response()
         response.url = "https://jsonplaceholder.typicode.com/posts"
         response.status_code = 400
+        response.reason = "invalid request"
 
         with self.assertRaises(RestBadRequestError) as cm:
             raise_on_response_error(response)
@@ -26,20 +27,22 @@ class RaiseOnResponseErrorTests(unittest.TestCase):
         exc = cm.exception
         self.assertIs(exc.response, response)
         self.assertEqual(
-            "Bad request for resource https://jsonplaceholder.typicode.com/posts", str(exc)
+            "Bad request for resource https://jsonplaceholder.typicode.com/posts (invalid request)",
+            str(exc),
         )
 
     def test_raise_on_404(self):
         response = requests.Response()
         response.url = "https://jsonplaceholder.typicode.com/posts"
         response.status_code = 404
+        response.reason = "page does not exist"
 
         with self.assertRaises(RestResourceNotFoundError) as cm:
             raise_on_response_error(response)
 
         exc = cm.exception
         self.assertIs(exc.response, response)
-        self.assertEqual("Object could not be found in database", str(exc))
+        self.assertEqual("Object could not be found in database (page does not exist)", str(exc))
 
     @ddt.data(401, 402, 403)
     def test_raise_on_40x(self, status_code):

--- a/test/test_jsonplaceholder.py
+++ b/test/test_jsonplaceholder.py
@@ -189,10 +189,10 @@ class TestJsonPlaceHolder(unittest.TestCase):
         api = qrest.API(jsonplaceholderconfig)
         api.upload_file.response = ContentResponse()
 
-        file = open(qrest.__file__, 'rb')
+        file = open(qrest.__file__, "rb")
 
         with mock.patch("requests.request", return_value=self.mock_response) as mock_request:
-            response = api.upload_file.get_response(file=('__init__.py', file))
+            response = api.upload_file.get_response(file=("__init__.py", file))
 
             mock_request.assert_called_with(
                 method="POST",
@@ -201,7 +201,7 @@ class TestJsonPlaceHolder(unittest.TestCase):
                 url="https://jsonplaceholder.typicode.com/files",
                 params={},
                 json={},
-                files=[('file', ('__init__.py', file))],
+                files=[("file", ("__init__.py", file))],
                 headers={"Content-type": "application/json; charset=UTF-8"},
             )
             self.assertIs(api.upload_file.response, response)
@@ -210,7 +210,7 @@ class TestJsonPlaceHolder(unittest.TestCase):
         api = qrest.API(jsonplaceholderconfig)
         api.create_post_with_schema.response = ContentResponse()
 
-        post = {'user': 'Alice', 'body': 'Something about bob'}
+        post = {"user": "Alice", "body": "Something about bob"}
 
         with mock.patch("requests.request", return_value=self.mock_response) as mock_request:
             response = api.create_post_with_schema.get_response(post=post)
@@ -232,7 +232,7 @@ class TestJsonPlaceHolder(unittest.TestCase):
         api.create_post_with_schema.response = ContentResponse()
 
         # parameter that does not obey the schema
-        post = {'user': 'Alice', 'message': 'Something about bob'}
+        post = {"user": "Alice", "message": "Something about bob"}
 
         with self.assertRaises(RestClientValidationError) as exc:
             api.create_post_with_schema.get_response(post=post)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py37, py37-{test, flake8, black, coverage, docs}
+envlist = py38, py38-{test, flake8, black, coverage, docs}
 
-[testenv:py37]
+[testenv:py38]
 extras = dev
 # to silence the warning tox shows about discarding the PYTHONPATH
 setenv = PYTHONPATH = ""
@@ -11,8 +11,8 @@ deps =
 commands =
     pytest
 
-[testenv:py37-{test, flake8, black, coverage, docs}]
-envdir = {toxworkdir}/py37-dev
+[testenv:py38-{test, flake8, black, coverage, docs}]
+envdir = {toxworkdir}/py38-dev
 # to silence the warning tox shows about discarding the PYTHONPATH
 setenv = PYTHONPATH = ""
 skip_install = true


### PR DESCRIPTION
This pull request addresses the following:

* exceptions that qrest raises because the response has a status code that indicates an error, also contain the original `requests.Response` object to help clients determine the cause of the error;
* replaces exception class `RestResouceHTTPError`, which raised the appropriate exception but wasn't used by an exception itself, by a function.

The changes related to the main goals of this pull request can mostly be found in `resource.py` and `exception.py`.

While addressing the above, the following issues were also tackled:

* Some Python files weren't formatted according to the auto-formatter Black.
* Although some Python files contain type hints, these type hints are never checked and often incorrect. This pull request configures the type hint checker mypy for `resource.py` and fixes all type hints in that module. Fixing all type hints is a pull request in itself but at least a start is made.
* The tox configuration is updated to setup a development virtualenv for Python 3.8. Note that `setup.py` still specifies a minimum Python version of 3.6 but this isn't actually checked.

**Main goals**

Currently when you use qrest to access an endpoint and that endpoint returns a 400 or 404, qrest raises a `RestBadRequestError` or `RestResourceNotFoundError` with a rather non-descriptive message:
``` python
if self.code == 400:
    raise RestBadRequestError("Bad request for resource %s" % (self.response.url,))
elif self.code == 404:
  raise RestResourceNotFoundError("Object could not be found in database")
```
These exceptions don't provide the error information of the actual response, which makes it difficult for clients to determine why they received a 400 or 404. This pull requests adds the actual response object to these exceptions.

This pull request **also** addresses the init dunder of a RestResourceHTTPError, which raises the error that the client sees. Currently this class looks like this:
``` python
class RestResourceHTTPError(HTTPError):
    def __init__(self, response_object, *args, **kwargs):
        self.response = response_object
        self.code = self.response.status_code
        self.reason = self.response.reason
 
        if self.code == 400:
            raise RestBadRequestError("Bad request for resource %s" % (self.response.url,))
        elif self.code == 404:
            raise RestResourceNotFoundError("Object could not be found in database")
        elif self.code in (401, 402, 403):
            raise RestAccessDeniedError(
                "error %d: Access is denied to resource %s" % (self.code, self.response.url)
            )
        elif self.code in (500,):
            raise RestInternalServerError(
                "error %d: Internal Server error (%s)" % (self.code, self.reason)
            )
        else:
            raise Exception("REST error %d: %s" % (self.code, self.reason))
```
This exception class isn't used as an exception itself but is an exception factory. This pull request replaces that exception class by a factory function:
``` python
def raise_on_response_error(response: requests.Response):
   …
```